### PR TITLE
Update bufSize to fix truncation

### DIFF
--- a/src/utils/blake3tools.ts
+++ b/src/utils/blake3tools.ts
@@ -111,7 +111,7 @@ export function extractB3hashFromMHash(mHash: Buffer): Buffer {
  */
 export function generateCIDFromMHash(mHash: Buffer, file: File): Buffer {
   // Buffer size for storing the file size
-  const bufSize = 8;
+  const bufSize = 16;
 
   // Concatenate the CID parts
   const cid: Buffer = Buffer.concat([

--- a/src/utils/blake3tools.ts
+++ b/src/utils/blake3tools.ts
@@ -111,7 +111,7 @@ export function extractB3hashFromMHash(mHash: Buffer): Buffer {
  */
 export function generateCIDFromMHash(mHash: Buffer, file: File): Buffer {
   // Buffer size for storing the file size
-  const bufSize = 4;
+  const bufSize = 8;
 
   // Concatenate the CID parts
   const cid: Buffer = Buffer.concat([


### PR DESCRIPTION
File sizes bigger than 4GB have their size truncated in 4 bytes causing incorrect CID generated.